### PR TITLE
Add AI practice recommendations feature

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     depends_on:
       - db
     environment:
+      - DEBUG=True
       - OPENAI_API_KEY
   db:
     image: postgres:13

--- a/frontend/next-app/src/app/dashboard/page.tsx
+++ b/frontend/next-app/src/app/dashboard/page.tsx
@@ -127,10 +127,13 @@ export default function DashboardPage() {
             See your complete practice history and charts
           </p>
         </div>
-        <div className="cursor-pointer rounded-lg border bg-card p-6 hover:bg-accent transition-colors opacity-50 cursor-not-allowed">
+        <div
+          onClick={() => router.push('/recommendations')}
+          className="cursor-pointer rounded-lg border bg-card p-6 hover:bg-accent transition-colors"
+        >
           <h3 className="font-semibold mb-2">Practice Recommendations</h3>
           <p className="text-sm text-muted-foreground">
-            Get AI-powered practice suggestions (Coming soon)
+            Get AI-powered practice suggestions
           </p>
         </div>
       </div>

--- a/frontend/next-app/src/app/recommendations/page.tsx
+++ b/frontend/next-app/src/app/recommendations/page.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import axios from "axios";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Loader2 } from "lucide-react";
+
+export default function RecommendationsPage() {
+  const router = useRouter();
+  const [instrument, setInstrument] = useState("");
+  const [skillLevel, setSkillLevel] = useState("");
+  const [goals, setGoals] = useState("");
+  const [recommendation, setRecommendation] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const apiBaseUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000/api/v1";
+
+  useEffect(() => {
+    const token = localStorage.getItem("token");
+    if (!token) {
+      router.push("/login");
+    }
+  }, [router]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setRecommendation("");
+    setIsLoading(true);
+
+    const token = localStorage.getItem("token");
+    if (!token) {
+      router.push("/login");
+      return;
+    }
+
+    try {
+      const response = await axios.post(
+        `${apiBaseUrl}/recommendations/`,
+        { instrument, skill_level: skillLevel, goals },
+        { headers: { Authorization: `Token ${token}` } }
+      );
+      setRecommendation(response.data.recommendation);
+    } catch (err: unknown) {
+      if (axios.isAxiosError(err) && err.response?.data?.error) {
+        setError(err.response.data.error);
+      } else {
+        setError("Failed to get recommendation. Please try again.");
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const selectClassName =
+    "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2";
+
+  return (
+    <div className="container mx-auto p-4 md:p-8 max-w-2xl">
+      <div className="mb-8">
+        <h1 className="text-3xl md:text-4xl font-bold tracking-tight">
+          Practice Recommendations
+        </h1>
+        <p className="text-muted-foreground mt-2">
+          Get AI-powered practice suggestions tailored to your skill level and goals
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Get a Recommendation</CardTitle>
+          <CardDescription>
+            Fill in your details and we&apos;ll generate a personalized practice plan
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="instrument">Instrument</Label>
+              <select
+                id="instrument"
+                value={instrument}
+                onChange={(e) => setInstrument(e.target.value)}
+                className={selectClassName}
+                required
+                disabled={isLoading}
+              >
+                <option value="">Select an instrument</option>
+                <option value="guitar">Guitar</option>
+                <option value="piano">Piano</option>
+                <option value="drums">Drums</option>
+                <option value="bass">Bass</option>
+              </select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="skillLevel">Skill Level</Label>
+              <select
+                id="skillLevel"
+                value={skillLevel}
+                onChange={(e) => setSkillLevel(e.target.value)}
+                className={selectClassName}
+                required
+                disabled={isLoading}
+              >
+                <option value="">Select your level</option>
+                <option value="beginner">Beginner</option>
+                <option value="intermediate">Intermediate</option>
+                <option value="advanced">Advanced</option>
+              </select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="goals">Goals</Label>
+              <Input
+                id="goals"
+                placeholder="e.g., improve finger picking, learn jazz chords..."
+                value={goals}
+                onChange={(e) => setGoals(e.target.value)}
+                required
+                disabled={isLoading}
+              />
+            </div>
+
+            {error && (
+              <p className="text-sm text-destructive">{error}</p>
+            )}
+
+            <Button type="submit" disabled={isLoading} className="w-full">
+              {isLoading ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Generating...
+                </>
+              ) : (
+                "Get Recommendation"
+              )}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+
+      {recommendation && (
+        <Card className="mt-6">
+          <CardHeader>
+            <CardTitle>Your Practice Recommendation</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="whitespace-pre-wrap text-sm leading-relaxed">
+              {recommendation}
+            </p>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/frontend/next-app/src/components/navigation/Header.tsx
+++ b/frontend/next-app/src/components/navigation/Header.tsx
@@ -16,6 +16,7 @@ export function Header() {
     { name: "Dashboard", href: "/dashboard" },
     { name: "Profile", href: "/profilepage" },
     { name: "Practice Timer", href: "/practice-timer" },
+    { name: "Recommendations", href: "/recommendations" },
   ];
 
   // Don't show header on login/register pages

--- a/frontend/next-app/src/components/navigation/MobileNav.tsx
+++ b/frontend/next-app/src/components/navigation/MobileNav.tsx
@@ -16,6 +16,7 @@ export function MobileNav() {
     { name: "Dashboard", href: "/dashboard" },
     { name: "Profile", href: "/profilepage" },
     { name: "Practice Timer", href: "/practice-timer" },
+    { name: "Recommendations", href: "/recommendations" },
   ];
 
   // Don't show on login/register pages

--- a/session/tests.py
+++ b/session/tests.py
@@ -6,6 +6,7 @@ from rest_framework.test import APITestCase, APIClient
 from rest_framework import status
 from rest_framework.authtoken.models import Token
 from datetime import timedelta, date, datetime
+from unittest.mock import patch, MagicMock
 
 from .models import Session, Tag
 
@@ -511,3 +512,79 @@ class TagAPITests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(Tag.objects.count(), 0)
+
+
+class RecommendationAPITests(APITestCase):
+    """Test cases for Practice Recommendation endpoint"""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.user = get_user_model().objects.create_user(
+            username="testuser",
+            email="test@email.com",
+            password="testpass123"
+        )
+        self.token = Token.objects.create(user=self.user)
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.key)
+        self.url = reverse('practice-recommendation')
+        self.valid_data = {
+            'instrument': 'guitar',
+            'skill_level': 'beginner',
+            'goals': 'improve finger picking technique'
+        }
+
+    def test_missing_fields_returns_400(self):
+        """Test that missing required fields returns 400"""
+        response = self.client.post(self.url, {}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('error', response.data)
+
+    def test_invalid_skill_level_returns_400(self):
+        """Test that invalid skill_level returns 400"""
+        data = {**self.valid_data, 'skill_level': 'expert'}
+        response = self.client.post(self.url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('error', response.data)
+
+    def test_invalid_instrument_returns_400(self):
+        """Test that invalid instrument returns 400"""
+        data = {**self.valid_data, 'instrument': 'theremin'}
+        response = self.client.post(self.url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('error', response.data)
+
+    @patch('session.views.OpenAI')
+    def test_successful_recommendation(self, mock_openai_cls):
+        """Test successful recommendation with mocked OpenAI"""
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = 'Practice scales for 15 minutes daily.'
+        mock_client.chat.completions.create.return_value = mock_response
+
+        response = self.client.post(self.url, self.valid_data, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['recommendation'], 'Practice scales for 15 minutes daily.')
+        self.assertEqual(response.data['instrument'], 'guitar')
+        self.assertEqual(response.data['skill_level'], 'beginner')
+        self.assertEqual(response.data['goals'], 'improve finger picking technique')
+
+    def test_unauthenticated_returns_401_or_403(self):
+        """Test that unauthenticated requests are rejected"""
+        self.client.credentials()
+        response = self.client.post(self.url, self.valid_data, format='json')
+        self.assertIn(response.status_code, [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN])
+
+    @patch('session.views.OpenAI')
+    def test_openai_error_returns_500(self, mock_openai_cls):
+        """Test that OpenAI API errors return 500"""
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_client.chat.completions.create.side_effect = Exception('API rate limit exceeded')
+
+        response = self.client.post(self.url, self.valid_data, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertIn('error', response.data)

--- a/session/views.py
+++ b/session/views.py
@@ -10,10 +10,8 @@ from .serializers import SessionSerializer, TagSerializer
 from django.db.models import Max, Sum, Count, Q
 from django.utils import timezone
 from datetime import timedelta, datetime
-import openai
+from openai import OpenAI
 import os
-
-openai.api_key = os.environ.get('OPENAI_API_KEY')
 
 class SessionList(generics.ListCreateAPIView):
     permission_classes = (IsAdminOrOwner,)
@@ -41,46 +39,40 @@ class PracticeRecommendationView(APIView):
     permission_classes = (IsAdminOrOwner,)
 
     def post(self, request):
-        user_id = request.data.get('user_id')
         skill_level = request.data.get('skill_level')
         instrument = request.data.get('instrument')
         goals = request.data.get('goals')
 
-        if not user_id or not skill_level or not instrument or not goals:
+        if not skill_level or not instrument or not goals:
             return Response({'error': 'Missing required fields'}, status=status.HTTP_400_BAD_REQUEST)
 
-        try:
-            user = User.objects.get(id=user_id)
-        except User.DoesNotExist:
-            return Response({'error': 'User not found'}, status=status.HTTP_404_NOT_FOUND)
+        valid_skill_levels = [choice[0] for choice in Session.SKILL_LEVEL_CHOICES]
+        if skill_level not in valid_skill_levels:
+            return Response({'error': f'Invalid skill_level. Must be one of: {", ".join(valid_skill_levels)}'}, status=status.HTTP_400_BAD_REQUEST)
 
-        prompt = f"Generate a practice recommendation for a {skill_level} level {instrument} player who wants to focus on {goals}."
+        valid_instruments = [choice[0] for choice in Session.INSTRUMENT_CHOICES]
+        if instrument not in valid_instruments:
+            return Response({'error': f'Invalid instrument. Must be one of: {", ".join(valid_instruments)}'}, status=status.HTTP_400_BAD_REQUEST)
 
         try:
-            response = openai.Completion.create(
-                engine='text-davinci-002',
-                prompt=prompt,
-                max_tokens=100,
-                n=1,
-                stop=None,
+            client = OpenAI(api_key=os.environ.get('OPENAI_API_KEY'))
+            response = client.chat.completions.create(
+                model='gpt-4o-mini',
+                messages=[
+                    {'role': 'system', 'content': 'You are an experienced music teacher who provides detailed, actionable practice recommendations.'},
+                    {'role': 'user', 'content': f'Generate a practice recommendation for a {skill_level} level {instrument} player who wants to focus on {goals}.'}
+                ],
+                max_tokens=1000,
                 temperature=0.7,
             )
-            recommendation = response.choices[0].text.strip()
+            recommendation = response.choices[0].message.content.strip()
 
-            session_data = {
-                'user': user.id,
+            return Response({
+                'recommendation': recommendation,
                 'instrument': instrument,
                 'skill_level': skill_level,
                 'goals': goals,
-                'recommendation': recommendation,
-            }
-
-            serializer = SessionSerializer(data=session_data)
-            if serializer.is_valid():
-                session = serializer.save()
-                return Response(serializer.data, status=status.HTTP_201_CREATED)
-            else:
-                return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+            }, status=status.HTTP_200_OK)
 
         except Exception as e:
             return Response({'error': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
## Summary
- Rewrites `PracticeRecommendationView` to use OpenAI v1+ SDK (`gpt-4o-mini`) with input validation against model choices
- Creates a new `/recommendations` frontend page with auth-protected form, loading/error states, and AI-generated result display
- Adds "Recommendations" nav link to Header and MobileNav, enables dashboard quick action card
- Adds 6 mocked backend tests for the recommendation endpoint (all 34 tests passing)
- Fixes `DEBUG=True` in docker-compose so local dev tests don't get 301 redirects from `SECURE_SSL_REDIRECT`

## Test plan
- [x] Backend: `docker compose run --rm -e DEBUG=True web python manage.py test session -v2` — 34/34 pass
- [ ] Frontend: Navigate to `/recommendations`, fill form, submit (requires `OPENAI_API_KEY`)
- [ ] Verify nav link appears on desktop and mobile
- [ ] Verify dashboard quick action card links to `/recommendations`

🤖 Generated with [Claude Code](https://claude.com/claude-code)