### PR TITLE
fix: correct Railway deploy workflow

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Deploy to Railway
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
-        run: railway up --service backend
+        run: railway up --service MusiciansPracticeApp
 
   deploy-frontend:
     name: Deploy Frontend to Railway
@@ -102,4 +102,4 @@ jobs:
       - name: Deploy to Railway
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
-        run: railway up --service frontend --directory frontend/next-app
+        run: railway up --service frontend frontend/next-app


### PR DESCRIPTION
## Summary
- Fix backend service name from `backend` to `MusiciansPracticeApp` (matches actual Railway service)
- Fix frontend deploy CLI syntax: `--directory` is not a valid flag, use positional path arg instead
- RAILWAY_TOKEN GitHub secret has been added

## Test plan
- [ ] CI tests pass on this PR
- [ ] Merge triggers deploy jobs that connect to Railway successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)