### PR TITLE
feat: add email confirmation flow with SendGrid

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,25 @@ CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8000
 CSRF_TRUSTED_ORIGINS=http://localhost:3000
 
 # =========================
+# FRONTEND URL
+# =========================
+
+# Used for email confirmation links (must match your deployed frontend)
+# Example: https://frontend-production-65a2.up.railway.app
+FRONTEND_URL=http://localhost:3000
+
+# =========================
+# EMAIL (SendGrid)
+# =========================
+
+# SendGrid API key for transactional emails (signup confirmation, password reset)
+# Get yours at: https://app.sendgrid.com/settings/api_keys
+SENDGRID_API_KEY=your-sendgrid-api-key-here
+
+# The "From" address on outgoing emails
+DEFAULT_FROM_EMAIL=noreply@theshed.app
+
+# =========================
 # EXTERNAL SERVICES
 # =========================
 

--- a/accounts/adapter.py
+++ b/accounts/adapter.py
@@ -1,0 +1,12 @@
+import os
+from allauth.account.adapter import DefaultAccountAdapter
+
+
+class CustomAccountAdapter(DefaultAccountAdapter):
+    """Routes email confirmation links to the Next.js frontend."""
+
+    def get_email_confirmation_url(self, request, emailconfirmation):
+        frontend_url = os.getenv(
+            "FRONTEND_URL", "http://localhost:3000"
+        )
+        return f"{frontend_url}/verify-email?key={emailconfirmation.key}"

--- a/django_project/settings.py
+++ b/django_project/settings.py
@@ -91,9 +91,31 @@ TEMPLATES = [
     },
 ]
 
-EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+# Email Configuration
+# In development (DEBUG=True), emails print to console.
+# In production, uses SendGrid SMTP.
+if DEBUG:
+    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+else:
+    EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+    EMAIL_HOST = "smtp.sendgrid.net"
+    EMAIL_PORT = 587
+    EMAIL_USE_TLS = True
+    EMAIL_HOST_USER = "apikey"  # SendGrid requires this literal string
+    EMAIL_HOST_PASSWORD = os.getenv("SENDGRID_API_KEY", "")
+    DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL", "noreply@theshed.app")
 
 SITE_ID = 1
+
+# django-allauth configuration
+ACCOUNT_EMAIL_REQUIRED = True
+ACCOUNT_EMAIL_VERIFICATION = "mandatory"
+ACCOUNT_CONFIRM_EMAIL_ON_GET = True
+ACCOUNT_EMAIL_CONFIRMATION_EXPIRE_DAYS = 3
+ACCOUNT_LOGIN_ON_EMAIL_CONFIRMATION = False
+ACCOUNT_EMAIL_SUBJECT_PREFIX = "[The Shed] "
+ACCOUNT_ADAPTER = "accounts.adapter.CustomAccountAdapter"
+LOGIN_URL = "/login"
 
 
 WSGI_APPLICATION = "django_project.wsgi.application"

--- a/frontend/next-app/src/app/verify-email/page.tsx
+++ b/frontend/next-app/src/app/verify-email/page.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+import { useSearchParams, useRouter } from 'next/navigation';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+export default function VerifyEmailPage() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const key = searchParams.get('key');
+  const [status, setStatus] = useState<'verifying' | 'success' | 'error'>('verifying');
+  const [errorMessage, setErrorMessage] = useState('');
+
+  useEffect(() => {
+    if (!key) {
+      setStatus('error');
+      setErrorMessage('No verification key found. Please check your email link.');
+      return;
+    }
+
+    const verifyEmail = async () => {
+      const apiBaseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1';
+      try {
+        await axios.post(`${apiBaseUrl}/dj-rest-auth/registration/verify-email/`, { key });
+        setStatus('success');
+      } catch {
+        setStatus('error');
+        setErrorMessage('This verification link is invalid or has expired. Please try registering again.');
+      }
+    };
+
+    verifyEmail();
+  }, [key]);
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-background">
+      <Card className="w-full max-w-sm bg-card text-card-foreground rounded-xl border border-border">
+        <CardHeader>
+          <CardTitle className="text-2xl text-foreground">
+            {status === 'verifying' && 'Verifying your email...'}
+            {status === 'success' && 'Email Verified!'}
+            {status === 'error' && 'Verification Failed'}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {status === 'verifying' && (
+            <p className="text-muted-foreground">Please wait while we verify your email address.</p>
+          )}
+          {status === 'success' && (
+            <>
+              <p className="text-muted-foreground">
+                Your email has been confirmed. You can now sign in to your account.
+              </p>
+              <Button
+                onClick={() => router.push('/login')}
+                className="w-full bg-gradient-to-r from-primary to-[#8455ef] text-primary-foreground rounded-lg"
+              >
+                Sign In
+              </Button>
+            </>
+          )}
+          {status === 'error' && (
+            <>
+              <p className="text-muted-foreground">{errorMessage}</p>
+              <Button
+                onClick={() => router.push('/register')}
+                className="w-full bg-gradient-to-r from-primary to-[#8455ef] text-primary-foreground rounded-lg"
+              >
+                Back to Register
+              </Button>
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/next-app/src/components/auth/RegisterPage.tsx
+++ b/frontend/next-app/src/components/auth/RegisterPage.tsx
@@ -29,6 +29,7 @@ const RegisterPage = () => {
     password2: '',
   });
   const [errors, setErrors] = useState<FormErrors>({});
+  const [registered, setRegistered] = useState(false);
   const router = useRouter();
 
   const validate = () => {
@@ -53,9 +54,8 @@ const RegisterPage = () => {
       const apiUrl = `${apiBaseUrl}/dj-rest-auth/registration/`;
 
       try {
-        const response = await axios.post(apiUrl, formData);
-        console.log(response.data);
-        router.push('/login');
+        await axios.post(apiUrl, formData);
+        setRegistered(true);
       } catch (error) {
         console.error('Registration error', error);
         if (axios.isAxiosError(error)) {
@@ -66,6 +66,33 @@ const RegisterPage = () => {
         }
       }
     }
+  }
+
+  if (registered) {
+    return (
+      <div className="flex items-center justify-center min-h-screen bg-background">
+        <Card className="w-full max-w-sm bg-card text-card-foreground rounded-xl border border-border">
+          <CardHeader>
+            <CardTitle className="text-2xl text-foreground">Check Your Email</CardTitle>
+            <CardDescription className="text-muted-foreground">
+              We&apos;ve sent a confirmation link to <strong>{formData.email}</strong>. Click the link to verify your account, then sign in.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-center text-sm text-muted-foreground">
+              Didn&apos;t get the email? Check your spam folder or{" "}
+              <button
+                onClick={() => setRegistered(false)}
+                className="text-primary hover:underline"
+              >
+                try again
+              </button>
+              .
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
Users were not receiving confirmation emails on signup because the app
used the console email backend with no SMTP config. This adds:

- SendGrid SMTP backend for production (console backend kept for dev)
- django-allauth mandatory email verification
- Custom adapter to route confirmation links to the Next.js frontend
- /verify-email page that confirms the key via the API
- "Check your email" screen after registration instead of auto-redirect

Requires SENDGRID_API_KEY and FRONTEND_URL env vars in production.

https://claude.ai/code/session_01MCTqsuwqBS7nSRiikNyKi1