### PR TITLE
ci: split workflow into test and deploy pipelines

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
-name: Test and Deploy
+name: Test
 
 on:
-  push:
+  pull_request:
     branches: [main]
 
 jobs:
@@ -67,35 +67,3 @@ jobs:
       - name: Run test coverage
         working-directory: frontend/next-app
         run: npm run test:coverage
-
-  deploy-backend:
-    name: Deploy Backend to Railway
-    needs: [test-backend, test-frontend]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Railway CLI
-        run: npm install -g @railway/cli
-
-      - name: Deploy to Railway
-        env:
-          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
-        run: railway up --service MusiciansPracticeApp
-
-  deploy-frontend:
-    name: Deploy Frontend to Railway
-    needs: [test-backend, test-frontend]
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Railway CLI
-        run: npm install -g @railway/cli
-
-      - name: Deploy to Railway
-        working-directory: frontend/next-app
-        env:
-          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
-        run: railway up --service frontend


### PR DESCRIPTION
## Summary
- Adds `test.yml` — triggers on PRs to main, runs backend + frontend tests only
- Updates `test-and-deploy.yml` — triggers only on push to main, removes redundant `if` guards on deploy jobs
- Gives clear separation in the Actions UI between PR test runs and main deploy runs

## Test plan
- [ ] Open a test PR and verify only "Test" workflow runs
- [ ] Merge to main and verify "Test and Deploy" workflow runs with deploy steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)