### PR TITLE
feat(auth): email verification with magic-link auto-login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,3 +50,18 @@ CSRF_TRUSTED_ORIGINS=http://localhost:3000
 
 # OpenAI API Key (for AI features)
 OPENAI_API_KEY=your-openai-api-key-here
+
+# ─── Email (issue #16) ───────────────────────────────────────────────
+# SendGrid sender API key. When set, Django switches to SMTP.
+# When unset, the console backend prints emails to the web logs (fine for dev).
+# Create at https://app.sendgrid.com/settings/api_keys — needs "Mail Send" permission.
+SENDGRID_API_KEY=
+
+# The "From" address on verification emails. Must be a verified sender
+# (domain or single-sender) in the SendGrid dashboard before production use.
+DEFAULT_FROM_EMAIL=hello@theshed.app
+
+# Public URL of the Next.js frontend. The custom allauth adapter
+# generates confirmation links as ${FRONTEND_URL}/auth/verify/<key>.
+# In prod: the Railway frontend URL. In dev: http://localhost:3000.
+FRONTEND_URL=http://localhost:3000

--- a/accounts/adapter.py
+++ b/accounts/adapter.py
@@ -1,0 +1,16 @@
+import os
+from allauth.account.adapter import DefaultAccountAdapter
+
+
+class CustomAccountAdapter(DefaultAccountAdapter):
+    """Routes email confirmation links to the Next.js frontend's
+    /auth/verify/<key> page, which POSTs the key back to
+    /api/v1/dj-rest-auth/registration/verify-and-login/ and handles
+    auto-login on success.
+
+    FRONTEND_URL env var in prod; localhost fallback for dev.
+    """
+
+    def get_email_confirmation_url(self, request, emailconfirmation):
+        frontend_url = os.getenv("FRONTEND_URL", "http://localhost:3000")
+        return f"{frontend_url}/auth/verify/{emailconfirmation.key}"

--- a/accounts/migrations/0002_grandfather_existing_users.py
+++ b/accounts/migrations/0002_grandfather_existing_users.py
@@ -1,0 +1,18 @@
+from django.db import migrations
+from accounts.migrations._grandfather_helpers import grandfather_existing_emails
+
+
+def reverse_noop(apps, schema_editor):
+    """Forward-only — reversing would re-unverify everyone, the opposite of intent."""
+    pass
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("accounts", "0001_initial"),
+        ("account", "0009_emailaddress_unique_primary_email"),
+    ]
+
+    operations = [
+        migrations.RunPython(grandfather_existing_emails, reverse_noop),
+    ]

--- a/accounts/migrations/_grandfather_helpers.py
+++ b/accounts/migrations/_grandfather_helpers.py
@@ -1,0 +1,20 @@
+"""
+Forward function for the grandfather migration. Kept in a separate module
+(not on the migration class itself) so it's importable by tests without
+triggering migration-graph side effects.
+"""
+
+
+def grandfather_existing_emails(apps, schema_editor):
+    EmailAddress = apps.get_model("account", "EmailAddress")
+    User = apps.get_model("accounts", "CustomUser")
+
+    for user in User.objects.all():
+        email = (user.email or "").strip()
+        if not email:
+            continue
+        EmailAddress.objects.update_or_create(
+            user=user,
+            email=email,
+            defaults={"verified": True, "primary": True},
+        )

--- a/accounts/migrations/_grandfather_helpers.py
+++ b/accounts/migrations/_grandfather_helpers.py
@@ -14,9 +14,19 @@ def grandfather_existing_emails(apps, schema_editor):
         # this, a CustomUser.email of "Dan@Example.com" would miss an
         # existing lowercase EmailAddress row and attempt a duplicate INSERT
         # that trips allauth's partial unique-verified-email index.
-        email = (user.email or "").strip().lower()
+        original_email = user.email or ""
+        email = original_email.strip().lower()
         if not email:
             continue
+
+        # Normalize CustomUser.email too, so dj-rest-auth's login serializer
+        # (which does case-sensitive filter(email=user.email, verified=True))
+        # finds the lowercased EmailAddress row we're about to create/update.
+        # Without this, legacy users with mixed-case user.email get a verified
+        # EmailAddress row but cannot log in — permanent lockout.
+        if user.email != email:
+            user.email = email
+            user.save(update_fields=["email"])
 
         # Demote any OTHER primary rows for this user first. Allauth's
         # partial unique constraint on (user, primary=True) rejects a second

--- a/accounts/migrations/_grandfather_helpers.py
+++ b/accounts/migrations/_grandfather_helpers.py
@@ -10,9 +10,24 @@ def grandfather_existing_emails(apps, schema_editor):
     User = apps.get_model("accounts", "CustomUser")
 
     for user in User.objects.all():
-        email = (user.email or "").strip()
+        # Normalize to lowercase to match allauth's canonical form. Without
+        # this, a CustomUser.email of "Dan@Example.com" would miss an
+        # existing lowercase EmailAddress row and attempt a duplicate INSERT
+        # that trips allauth's partial unique-verified-email index.
+        email = (user.email or "").strip().lower()
         if not email:
             continue
+
+        # Demote any OTHER primary rows for this user first. Allauth's
+        # partial unique constraint on (user, primary=True) rejects a second
+        # primary=True for the same user; setting our target row primary
+        # without this step would IntegrityError on users who already have
+        # a primary row with a different email (leftover admin edits,
+        # reverted-migration debris, etc.).
+        EmailAddress.objects.filter(user=user, primary=True).exclude(
+            email__iexact=email
+        ).update(primary=False)
+
         EmailAddress.objects.update_or_create(
             user=user,
             email=email,

--- a/accounts/tests_adapter.py
+++ b/accounts/tests_adapter.py
@@ -1,0 +1,28 @@
+import os
+from unittest.mock import MagicMock, patch
+from django.test import TestCase
+from accounts.adapter import CustomAccountAdapter
+
+
+class CustomAccountAdapterTest(TestCase):
+    def test_confirmation_url_uses_frontend_url_env(self):
+        confirmation = MagicMock()
+        confirmation.key = "abc123"
+        adapter = CustomAccountAdapter()
+
+        with patch.dict(os.environ, {"FRONTEND_URL": "https://theshed.app"}):
+            url = adapter.get_email_confirmation_url(request=None, emailconfirmation=confirmation)
+
+        self.assertEqual(url, "https://theshed.app/auth/verify/abc123")
+
+    def test_confirmation_url_falls_back_to_localhost_in_dev(self):
+        confirmation = MagicMock()
+        confirmation.key = "xyz"
+        adapter = CustomAccountAdapter()
+
+        # Ensure FRONTEND_URL is unset for this test
+        env_without_frontend = {k: v for k, v in os.environ.items() if k != "FRONTEND_URL"}
+        with patch.dict(os.environ, env_without_frontend, clear=True):
+            url = adapter.get_email_confirmation_url(request=None, emailconfirmation=confirmation)
+
+        self.assertEqual(url, "http://localhost:3000/auth/verify/xyz")

--- a/accounts/tests_grandfather.py
+++ b/accounts/tests_grandfather.py
@@ -1,0 +1,53 @@
+from django.apps import apps as django_apps
+from django.test import TestCase
+from allauth.account.models import EmailAddress
+from accounts.models import CustomUser
+from accounts.migrations._grandfather_helpers import grandfather_existing_emails
+
+
+class GrandfatherMigrationTest(TestCase):
+    """The one-off data migration that makes pre-existing users verified."""
+
+    def test_creates_verified_primary_emailaddress_for_users_without_one(self):
+        user = CustomUser.objects.create_user(
+            username="legacy", email="legacy@example.com", password="x"
+        )
+        self.assertFalse(
+            EmailAddress.objects.filter(user=user).exists(),
+            "Pre-condition: legacy user has no EmailAddress row.",
+        )
+
+        grandfather_existing_emails(django_apps, None)
+
+        email = EmailAddress.objects.get(user=user)
+        self.assertEqual(email.email, "legacy@example.com")
+        self.assertTrue(email.verified)
+        self.assertTrue(email.primary)
+
+    def test_updates_existing_unverified_emailaddress(self):
+        user = CustomUser.objects.create_user(
+            username="halfdone", email="halfdone@example.com", password="x"
+        )
+        EmailAddress.objects.create(
+            user=user, email="halfdone@example.com", verified=False, primary=False
+        )
+
+        grandfather_existing_emails(django_apps, None)
+
+        email = EmailAddress.objects.get(user=user)
+        self.assertTrue(email.verified)
+        self.assertTrue(email.primary)
+
+    def test_skips_users_without_email(self):
+        user = CustomUser.objects.create_user(username="noemail", password="x")
+        grandfather_existing_emails(django_apps, None)
+        self.assertFalse(EmailAddress.objects.filter(user=user).exists())
+
+    def test_idempotent_second_run_is_noop(self):
+        CustomUser.objects.create_user(
+            username="twice", email="twice@example.com", password="x"
+        )
+        grandfather_existing_emails(django_apps, None)
+        count_after_first = EmailAddress.objects.count()
+        grandfather_existing_emails(django_apps, None)
+        self.assertEqual(EmailAddress.objects.count(), count_after_first)

--- a/accounts/tests_grandfather.py
+++ b/accounts/tests_grandfather.py
@@ -51,3 +51,46 @@ class GrandfatherMigrationTest(TestCase):
         count_after_first = EmailAddress.objects.count()
         grandfather_existing_emails(django_apps, None)
         self.assertEqual(EmailAddress.objects.count(), count_after_first)
+
+    def test_demotes_other_primary_emailaddress_rows(self):
+        """Users with a stale primary=True row on a different email get it
+        demoted, so the migration can set the target row primary without
+        tripping allauth's partial unique-primary constraint."""
+        user = CustomUser.objects.create_user(
+            username="dualprimary", email="target@example.com", password="x"
+        )
+        # Stale primary on an unrelated email — simulates leftover admin edit
+        # or reverted-migration debris.
+        EmailAddress.objects.create(
+            user=user, email="old@example.com", verified=False, primary=True
+        )
+
+        grandfather_existing_emails(django_apps, None)
+
+        new_row = EmailAddress.objects.get(user=user, email="target@example.com")
+        old_row = EmailAddress.objects.get(user=user, email="old@example.com")
+
+        self.assertTrue(new_row.verified)
+        self.assertTrue(new_row.primary)
+        self.assertFalse(old_row.primary)  # demoted
+
+    def test_normalizes_email_case_to_lowercase(self):
+        """CustomUser.email stored mixed-case finds an existing lowercase
+        EmailAddress row instead of attempting a duplicate insert."""
+        user = CustomUser.objects.create_user(
+            username="mixedcase", email="Mixed@Example.COM", password="x"
+        )
+        # Existing lowercase row — allauth's canonical form.
+        existing = EmailAddress.objects.create(
+            user=user, email="mixed@example.com", verified=False, primary=False
+        )
+
+        grandfather_existing_emails(django_apps, None)
+
+        # Exactly one EmailAddress row for this user — the existing one got
+        # updated, not a duplicate created.
+        self.assertEqual(EmailAddress.objects.filter(user=user).count(), 1)
+        existing.refresh_from_db()
+        self.assertEqual(existing.email, "mixed@example.com")  # unchanged
+        self.assertTrue(existing.verified)
+        self.assertTrue(existing.primary)

--- a/accounts/tests_grandfather.py
+++ b/accounts/tests_grandfather.py
@@ -94,3 +94,22 @@ class GrandfatherMigrationTest(TestCase):
         self.assertEqual(existing.email, "mixed@example.com")  # unchanged
         self.assertTrue(existing.verified)
         self.assertTrue(existing.primary)
+
+    def test_normalizes_customuser_email_to_lowercase(self):
+        """Legacy user with mixed-case CustomUser.email gets it normalized
+        so dj-rest-auth's case-sensitive login filter matches the lowercased
+        EmailAddress row. Without this fix, legacy mixed-case users hit a
+        permanent lockout after the mandatory-verify gate flips."""
+        user = CustomUser.objects.create_user(
+            username="legacycaps", email="Legacy@Example.COM", password="x"
+        )
+        grandfather_existing_emails(django_apps, None)
+
+        user.refresh_from_db()
+        self.assertEqual(user.email, "legacy@example.com")
+
+        # EmailAddress row should also be the lowercased form.
+        email_row = EmailAddress.objects.get(user=user)
+        self.assertEqual(email_row.email, "legacy@example.com")
+        self.assertTrue(email_row.verified)
+        self.assertTrue(email_row.primary)

--- a/accounts/tests_verify.py
+++ b/accounts/tests_verify.py
@@ -1,0 +1,90 @@
+from datetime import timedelta
+from django.test import TestCase
+from django.utils import timezone
+from rest_framework.test import APIClient
+from rest_framework.authtoken.models import Token
+from allauth.account.models import EmailAddress, EmailConfirmation, EmailConfirmationHMAC
+from accounts.models import CustomUser
+
+
+VERIFY_URL = "/api/v1/dj-rest-auth/registration/verify-and-login/"
+
+
+def _make_unverified_user_with_hmac():
+    user = CustomUser.objects.create_user(
+        username="new", email="new@example.com", password="x"
+    )
+    email = EmailAddress.objects.create(
+        user=user, email="new@example.com", verified=False, primary=True
+    )
+    hmac = EmailConfirmationHMAC(email)
+    return user, email, hmac.key
+
+
+class VerifyAndLoginTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+
+    def test_happy_path_confirms_email_and_returns_token(self):
+        user, email, key = _make_unverified_user_with_hmac()
+        resp = self.client.post(VERIFY_URL, {"key": key}, format="json")
+        self.assertEqual(resp.status_code, 200)
+
+        body = resp.json()
+        self.assertIn("key", body)
+        self.assertEqual(body["user"], user.pk)
+
+        email.refresh_from_db()
+        self.assertTrue(email.verified)
+
+        token = Token.objects.get(user=user)
+        self.assertEqual(body["key"], token.key)
+
+    def test_invalid_key_returns_404(self):
+        resp = self.client.post(VERIFY_URL, {"key": "definitely-not-a-key"}, format="json")
+        self.assertEqual(resp.status_code, 404)
+        self.assertEqual(resp.json()["detail"], "invalid_key")
+
+    def test_missing_key_returns_404(self):
+        resp = self.client.post(VERIFY_URL, {}, format="json")
+        self.assertEqual(resp.status_code, 404)
+        self.assertEqual(resp.json()["detail"], "invalid_key")
+
+    def test_already_verified_returns_409(self):
+        user, email, key = _make_unverified_user_with_hmac()
+        email.verified = True
+        email.save()
+
+        resp = self.client.post(VERIFY_URL, {"key": key}, format="json")
+        self.assertEqual(resp.status_code, 409)
+        self.assertEqual(resp.json()["detail"], "already_verified")
+
+    def test_expired_key_returns_410(self):
+        user, email, _ = _make_unverified_user_with_hmac()
+        # DB-stored path: row with sent older than expiry.
+        # Use the adapter to generate a proper key (objects.create() without key= leaves it empty).
+        from allauth.account.adapter import get_adapter
+        db_key = get_adapter().generate_emailconfirmation_key(email.email)
+        confirmation = EmailConfirmation.objects.create(
+            email_address=email,
+            sent=timezone.now() - timedelta(days=7),
+            key=db_key,
+        )
+        # Force the DB-stored key path (not HMAC) by POSTing the stored row's key.
+        resp = self.client.post(VERIFY_URL, {"key": confirmation.key}, format="json")
+        self.assertEqual(resp.status_code, 410)
+        self.assertEqual(resp.json()["detail"], "expired_key")
+
+    def test_reuses_existing_token_if_present(self):
+        user, email, key = _make_unverified_user_with_hmac()
+        existing_token = Token.objects.create(user=user)
+
+        resp = self.client.post(VERIFY_URL, {"key": key}, format="json")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["key"], existing_token.key)
+
+    def test_endpoint_is_public_no_auth_required(self):
+        user, email, key = _make_unverified_user_with_hmac()
+        # No credentials on client — endpoint must be AllowAny.
+        resp = self.client.post(VERIFY_URL, {"key": key}, format="json")
+        self.assertEqual(resp.status_code, 200)

--- a/accounts/tests_verify.py
+++ b/accounts/tests_verify.py
@@ -88,3 +88,25 @@ class VerifyAndLoginTests(TestCase):
         # No credentials on client — endpoint must be AllowAny.
         resp = self.client.post(VERIFY_URL, {"key": key}, format="json")
         self.assertEqual(resp.status_code, 200)
+
+    def test_expired_hmac_key_returns_410(self):
+        """Production path — allauth 65.x defaults to HMAC keys, so this is
+        the expiry code path real users will hit. Simulates an expired
+        HMAC by patching the clock signing.loads() reads."""
+        from unittest.mock import patch
+        import time
+
+        user, email, key = _make_unverified_user_with_hmac()
+
+        # Jump 8 days forward (past ACCOUNT_EMAIL_CONFIRMATION_EXPIRE_DAYS=1)
+        # so signing.loads raises SignatureExpired.
+        future = time.time() + 8 * 86400
+
+        with patch("django.core.signing.time.time", return_value=future):
+            resp = self.client.post(VERIFY_URL, {"key": key}, format="json")
+
+        self.assertEqual(resp.status_code, 410)
+        self.assertEqual(resp.json()["detail"], "expired_key")
+        # Sanity: email is still unverified — expired keys don't confirm.
+        email.refresh_from_db()
+        self.assertFalse(email.verified)

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,11 +1,16 @@
 from django.urls import path
 from .views import current_user_view, logout_view
-
+from .views_verify import verify_and_login_view
 
 
 urlpatterns = [
-        path('api/v1/current-user/', current_user_view, name='current-user'),
-        path('api/v1/logout/', logout_view, name='logout'),
+    path('api/v1/current-user/', current_user_view, name='current-user'),
+    path('api/v1/logout/', logout_view, name='logout'),
+    path(
+        'api/v1/dj-rest-auth/registration/verify-and-login/',
+        verify_and_login_view,
+        name='verify-and-login',
+    ),
 ]
 
 

--- a/accounts/views_verify.py
+++ b/accounts/views_verify.py
@@ -1,0 +1,94 @@
+from django.core import signing
+from rest_framework import status
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.authtoken.models import Token
+from allauth.account import app_settings as allauth_settings
+from allauth.account.models import EmailAddress, EmailConfirmation, EmailConfirmationHMAC
+
+
+def _resolve_confirmation(key):
+    """Return (confirmation, email_address, already_verified, expired) tuple.
+
+    Tries HMAC first (allauth 65.x default), then DB-stored fallback.
+    Returns (None, None, False, False) if the key is completely unrecognisable.
+    """
+    # --- HMAC path ---
+    # EmailConfirmationHMAC.from_key() only returns a result when verified=False.
+    # We need to detect the already-verified case, so we decode the PK ourselves
+    # and look up the EmailAddress regardless of its verified flag.
+    try:
+        max_age = 60 * 60 * 24 * allauth_settings.EMAIL_CONFIRMATION_EXPIRE_DAYS
+        pk = signing.loads(key, max_age=max_age, salt=allauth_settings.SALT)
+        try:
+            email_address = EmailAddress.objects.get(pk=pk)
+        except EmailAddress.DoesNotExist:
+            return None, None, False, False
+        if email_address.verified:
+            return None, email_address, True, False
+        confirmation = EmailConfirmationHMAC(email_address)
+        return confirmation, email_address, False, False
+    except signing.SignatureExpired:
+        # HMAC key structurally valid but past max_age — treat as expired.
+        # We can't easily return a proper 410 here without the PK, but for
+        # HMAC keys allauth's key_expired() always returns False (stateless).
+        # In practice the HMAC token IS the expiry mechanism; we surface 410.
+        return None, None, False, True
+    except signing.BadSignature:
+        pass  # Not an HMAC key — fall through to DB path.
+
+    # --- DB-stored path (legacy / compatibility) ---
+    # Query all rows (not just all_valid()) so we can distinguish expired vs missing.
+    confirmation = (
+        EmailConfirmation.objects.select_related("email_address__user")
+        .filter(key=key.lower())
+        .first()
+    )
+    if confirmation is None:
+        return None, None, False, False
+    if confirmation.email_address.verified:
+        return None, confirmation.email_address, True, False
+    if confirmation.key_expired():
+        return None, None, False, True
+    return confirmation, confirmation.email_address, False, False
+
+
+@api_view(["POST"])
+@permission_classes([AllowAny])
+def verify_and_login_view(request):
+    """Confirm an email-verification key AND issue an auth token in one
+    round-trip. Used by the Next.js /auth/verify/<key> page to make
+    "click link in email = logged in" a single click from the user's
+    perspective, on any device.
+
+    Response shape ({key, user}) mirrors /dj-rest-auth/login/ so the
+    frontend uses identical token-storage code.
+
+    Status codes:
+      200 — confirmed, token issued
+      404 — invalid or missing key
+      409 — already verified (re-click of a spent HMAC)
+      410 — key expired past ACCOUNT_EMAIL_CONFIRMATION_EXPIRE_DAYS
+    """
+    key = request.data.get("key", "")
+    if not key:
+        return Response({"detail": "invalid_key"}, status=status.HTTP_404_NOT_FOUND)
+
+    confirmation, email_address, already_verified, expired = _resolve_confirmation(key)
+
+    if already_verified:
+        return Response({"detail": "already_verified"}, status=status.HTTP_409_CONFLICT)
+
+    if expired:
+        return Response({"detail": "expired_key"}, status=status.HTTP_410_GONE)
+
+    if confirmation is None:
+        return Response({"detail": "invalid_key"}, status=status.HTTP_404_NOT_FOUND)
+
+    confirmation.confirm(request)  # allauth flips verified=True and fires signals
+    user = confirmation.email_address.user
+    token, _ = Token.objects.get_or_create(user=user)
+    return Response(
+        {"key": token.key, "user": user.pk}, status=status.HTTP_200_OK
+    )

--- a/django_project/settings.py
+++ b/django_project/settings.py
@@ -98,6 +98,7 @@ SITE_ID = 1
 # ─── Allauth + email verification (see issue #16) ────────────────────
 ACCOUNT_EMAIL_VERIFICATION = "mandatory"
 ACCOUNT_EMAIL_REQUIRED = True
+ACCOUNT_EMAIL_SUBJECT_PREFIX = "[The Shed] "
 ACCOUNT_USERNAME_REQUIRED = True
 ACCOUNT_LOGIN_METHODS = {"username", "email"}
 ACCOUNT_CONFIRM_EMAIL_ON_GET = False  # our POST /verify-and-login/ handles it

--- a/django_project/settings.py
+++ b/django_project/settings.py
@@ -77,7 +77,7 @@ ROOT_URLCONF = "django_project.urls"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [],
+        "DIRS": [BASE_DIR / "templates"],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [
@@ -94,6 +94,31 @@ TEMPLATES = [
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
 SITE_ID = 1
+
+# ─── Allauth + email verification (see issue #16) ────────────────────
+ACCOUNT_EMAIL_VERIFICATION = "mandatory"
+ACCOUNT_EMAIL_REQUIRED = True
+ACCOUNT_USERNAME_REQUIRED = True
+ACCOUNT_LOGIN_METHODS = {"username", "email"}
+ACCOUNT_CONFIRM_EMAIL_ON_GET = False  # our POST /verify-and-login/ handles it
+ACCOUNT_EMAIL_CONFIRMATION_EXPIRE_DAYS = 1
+ACCOUNT_ADAPTER = "accounts.adapter.CustomAccountAdapter"
+
+DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL", "hello@theshed.app")
+
+# SendGrid in prod; console backend (already set above) stays default in dev.
+if os.getenv("SENDGRID_API_KEY"):
+    EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+    EMAIL_HOST = "smtp.sendgrid.net"
+    EMAIL_PORT = 587
+    EMAIL_HOST_USER = "apikey"
+    EMAIL_HOST_PASSWORD = os.getenv("SENDGRID_API_KEY")
+    EMAIL_USE_TLS = True
+
+# Fail fast if FRONTEND_URL is missing in a non-debug env. Must come after
+# DEBUG is set above.
+from django_project.startup_checks import check_frontend_url  # noqa: E402
+check_frontend_url()
 
 
 WSGI_APPLICATION = "django_project.wsgi.application"

--- a/django_project/startup_checks.py
+++ b/django_project/startup_checks.py
@@ -1,0 +1,24 @@
+"""Fail-fast checks that run during Django settings finalization.
+
+These exist to catch misconfigurations that would otherwise cause
+silent production failures — e.g., FRONTEND_URL unset in prod would
+make the CustomAccountAdapter emit confirmation links pointing at
+http://localhost:3000, which users would see as broken links.
+"""
+import os
+
+
+def check_frontend_url():
+    """Require FRONTEND_URL in env when DEBUG is False. In DEBUG mode
+    the CustomAccountAdapter falls back to http://localhost:3000, which
+    is correct for local dev but a broken-link failure in prod."""
+    from django.conf import settings
+    from django.core.exceptions import ImproperlyConfigured
+
+    if settings.DEBUG:
+        return
+    if not os.getenv("FRONTEND_URL"):
+        raise ImproperlyConfigured(
+            "FRONTEND_URL env var is required when DEBUG=False. "
+            "Confirmation emails will send broken links otherwise."
+        )

--- a/django_project/tests_settings.py
+++ b/django_project/tests_settings.py
@@ -1,0 +1,42 @@
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from django.test import TestCase
+
+
+class AuthSettingsTest(TestCase):
+    def test_email_verification_is_mandatory(self):
+        self.assertEqual(settings.ACCOUNT_EMAIL_VERIFICATION, "mandatory")
+
+    def test_email_required(self):
+        self.assertTrue(settings.ACCOUNT_EMAIL_REQUIRED)
+
+    def test_confirm_email_on_get_is_disabled(self):
+        # We handle confirmation via our own POST endpoint; allauth's
+        # GET-based confirm view would bypass the auto-login path.
+        self.assertFalse(settings.ACCOUNT_CONFIRM_EMAIL_ON_GET)
+
+    def test_confirmation_expiry_is_one_day(self):
+        self.assertEqual(settings.ACCOUNT_EMAIL_CONFIRMATION_EXPIRE_DAYS, 1)
+
+    def test_custom_adapter_is_configured(self):
+        self.assertEqual(
+            settings.ACCOUNT_ADAPTER, "accounts.adapter.CustomAccountAdapter"
+        )
+
+    def test_templates_dirs_includes_repo_root_templates(self):
+        dirs = settings.TEMPLATES[0]["DIRS"]
+        self.assertTrue(
+            any(str(d).endswith("templates") for d in dirs),
+            f"Expected 'templates' entry in TEMPLATES[0]['DIRS'], got {dirs}",
+        )
+
+    def test_default_from_email_set(self):
+        self.assertTrue(settings.DEFAULT_FROM_EMAIL)
+
+    def test_frontend_url_guard_module_exists(self):
+        # The guard is imported from django_project.startup_checks.
+        # If FRONTEND_URL is unset AND DEBUG is False, import raises
+        # ImproperlyConfigured. Verify the module is importable and the
+        # function is callable.
+        from django_project.startup_checks import check_frontend_url
+        self.assertTrue(callable(check_frontend_url))

--- a/django_project/tests_startup_checks.py
+++ b/django_project/tests_startup_checks.py
@@ -1,0 +1,25 @@
+import os
+from unittest.mock import patch
+from django.core.exceptions import ImproperlyConfigured
+from django.test import TestCase, override_settings
+from django_project.startup_checks import check_frontend_url
+
+
+class CheckFrontendUrlTest(TestCase):
+    @override_settings(DEBUG=False)
+    def test_raises_when_frontend_url_missing_and_debug_false(self):
+        env_without = {k: v for k, v in os.environ.items() if k != "FRONTEND_URL"}
+        with patch.dict(os.environ, env_without, clear=True):
+            with self.assertRaises(ImproperlyConfigured):
+                check_frontend_url()
+
+    @override_settings(DEBUG=False)
+    def test_passes_when_frontend_url_set_and_debug_false(self):
+        with patch.dict(os.environ, {"FRONTEND_URL": "https://theshed.app"}):
+            check_frontend_url()  # no raise
+
+    @override_settings(DEBUG=True)
+    def test_passes_when_debug_true_regardless_of_env(self):
+        env_without = {k: v for k, v in os.environ.items() if k != "FRONTEND_URL"}
+        with patch.dict(os.environ, env_without, clear=True):
+            check_frontend_url()  # no raise — dev has localhost fallback

--- a/frontend/next-app/src/app/auth/check-email/page.test.tsx
+++ b/frontend/next-app/src/app/auth/check-email/page.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import axios from "axios";
+import CheckEmailPage from "./page";
+
+jest.mock("axios");
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const mockSearchParams = new URLSearchParams();
+jest.mock("next/navigation", () => ({
+  useSearchParams: () => mockSearchParams,
+}));
+
+describe("CheckEmailPage", () => {
+  beforeEach(() => {
+    mockedAxios.post.mockReset();
+    mockSearchParams.delete("email");
+  });
+
+  it("renders the email address from search params", () => {
+    mockSearchParams.set("email", "user@example.com");
+    render(<CheckEmailPage />);
+    expect(screen.getByText(/user@example\.com/i)).toBeInTheDocument();
+  });
+
+  it("renders a fallback message when email param is missing", () => {
+    render(<CheckEmailPage />);
+    expect(screen.getByText(/check your email/i)).toBeInTheDocument();
+  });
+
+  it("resend button POSTs to /registration/resend-email/ with the email", async () => {
+    mockSearchParams.set("email", "user@example.com");
+    mockedAxios.post.mockResolvedValueOnce({ data: { detail: "ok" } });
+
+    render(<CheckEmailPage />);
+    fireEvent.click(screen.getByRole("button", { name: /resend/i }));
+
+    await waitFor(() => {
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        expect.stringContaining("/dj-rest-auth/registration/resend-email/"),
+        { email: "user@example.com" }
+      );
+    });
+  });
+
+  it("shows a success message after a successful resend", async () => {
+    mockSearchParams.set("email", "user@example.com");
+    mockedAxios.post.mockResolvedValueOnce({ data: { detail: "ok" } });
+
+    render(<CheckEmailPage />);
+    fireEvent.click(screen.getByRole("button", { name: /resend/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/sent/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/next-app/src/app/auth/check-email/page.tsx
+++ b/frontend/next-app/src/app/auth/check-email/page.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import React, { Suspense, useState } from "react";
+import Link from "next/link";
+import axios from "axios";
+import { useSearchParams } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { EnvelopeSimple } from "@phosphor-icons/react";
+
+const apiBaseUrl =
+  process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000/api/v1";
+
+function CheckEmailContent() {
+  const searchParams = useSearchParams();
+  const email = searchParams.get("email") ?? "";
+  const [isResending, setIsResending] = useState(false);
+  const [resendState, setResendState] = useState<"idle" | "sent" | "error">("idle");
+
+  const handleResend = async () => {
+    if (!email) return;
+    setIsResending(true);
+    setResendState("idle");
+    try {
+      await axios.post(
+        `${apiBaseUrl}/dj-rest-auth/registration/resend-email/`,
+        { email }
+      );
+      setResendState("sent");
+    } catch {
+      setResendState("error");
+    } finally {
+      setIsResending(false);
+    }
+  };
+
+  return (
+    <div className="min-h-[100dvh] bg-background flex items-center justify-center px-4 py-16">
+      <div className="w-full max-w-md rounded-[1.5rem] bg-card p-8 border border-border">
+        <div className="mx-auto w-fit rounded-full bg-primary/10 p-3 text-primary">
+          <EnvelopeSimple size={24} weight="regular" />
+        </div>
+        <h1 className="mt-4 text-2xl font-extrabold tracking-tight text-foreground text-center">
+          Check your email
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground text-center">
+          {email
+            ? <>We sent a link to <strong className="text-foreground">{email}</strong>. Click it to finish setting up your account.</>
+            : <>We sent you a link to finish setting up your account.</>}
+        </p>
+
+        <Button
+          onClick={handleResend}
+          disabled={isResending || !email}
+          className="mt-6 w-full h-11 rounded-lg"
+          variant="secondary"
+        >
+          {isResending ? "Sending..." : "Resend link"}
+        </Button>
+
+        {resendState === "sent" && (
+          <p className="mt-3 text-sm text-success text-center">Sent! Check your inbox.</p>
+        )}
+        {resendState === "error" && (
+          <p className="mt-3 text-sm text-destructive text-center">
+            Couldn&apos;t resend. Try again in a moment.
+          </p>
+        )}
+
+        <p className="mt-6 text-xs text-muted-foreground text-center">
+          Wrong email? <Link href="/register" className="text-primary hover:underline">Register again</Link>
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default function CheckEmailPage() {
+  return (
+    <Suspense fallback={<div className="min-h-[100dvh] bg-background" />}>
+      <CheckEmailContent />
+    </Suspense>
+  );
+}

--- a/frontend/next-app/src/app/auth/verify/[key]/page.test.tsx
+++ b/frontend/next-app/src/app/auth/verify/[key]/page.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import axios, { AxiosError } from "axios";
+import VerifyPage from "./page";
+
+jest.mock("axios");
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+  useParams: () => ({ key: "test-key-123" }),
+}));
+
+// Map-backed localStorage for round-trip assertions (jest.setup.ts stubs don't persist).
+const installRealLocalStorage = () => {
+  const store = new Map<string, string>();
+  Object.defineProperty(window, "localStorage", {
+    value: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => {
+        store.set(k, v);
+      },
+      removeItem: (k: string) => {
+        store.delete(k);
+      },
+      clear: () => store.clear(),
+      key: () => null,
+      length: 0,
+    },
+    configurable: true,
+    writable: true,
+  });
+};
+
+describe("VerifyPage", () => {
+  beforeEach(() => {
+    mockedAxios.post.mockReset();
+    mockedAxios.isAxiosError.mockImplementation(
+      (err): err is AxiosError => Boolean(err && (err as any).isAxiosError)
+    );
+    mockPush.mockReset();
+    installRealLocalStorage();
+  });
+
+  it("on 200 success, stores token + userId and redirects to /dashboard", async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: { key: "tok-abc", user: 42 },
+    });
+    render(<VerifyPage />);
+
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/dashboard"));
+    expect(window.localStorage.getItem("token")).toBe("tok-abc");
+    expect(window.localStorage.getItem("userId")).toBe("42");
+  });
+
+  it("on 410 expired, renders expired state with resend affordance", async () => {
+    mockedAxios.post.mockRejectedValueOnce({
+      isAxiosError: true,
+      response: { status: 410, data: { detail: "expired_key" } },
+    });
+    render(<VerifyPage />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/link has expired/i)).toBeInTheDocument()
+    );
+    expect(screen.getByRole("button", { name: /send.*new.*link/i })).toBeInTheDocument();
+  });
+
+  it("on 404 invalid, renders invalid state with resend form", async () => {
+    mockedAxios.post.mockRejectedValueOnce({
+      isAxiosError: true,
+      response: { status: 404, data: { detail: "invalid_key" } },
+    });
+    render(<VerifyPage />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/isn.t valid/i)).toBeInTheDocument()
+    );
+  });
+
+  it("on 409 already-verified, renders login link", async () => {
+    mockedAxios.post.mockRejectedValueOnce({
+      isAxiosError: true,
+      response: { status: 409, data: { detail: "already_verified" } },
+    });
+    render(<VerifyPage />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/already verified/i)).toBeInTheDocument()
+    );
+    expect(screen.getByRole("link", { name: /go to login/i })).toHaveAttribute(
+      "href",
+      "/login"
+    );
+  });
+
+  it("expired state's resend form POSTs to /registration/resend-email/ with entered email", async () => {
+    mockedAxios.post.mockRejectedValueOnce({
+      isAxiosError: true,
+      response: { status: 410, data: { detail: "expired_key" } },
+    });
+    mockedAxios.post.mockResolvedValueOnce({ data: { detail: "ok" } });
+
+    render(<VerifyPage />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/link has expired/i)).toBeInTheDocument()
+    );
+
+    const input = screen.getByLabelText(/email/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "user@example.com" } });
+    fireEvent.click(screen.getByRole("button", { name: /send.*new.*link/i }));
+
+    await waitFor(() => {
+      const calls = mockedAxios.post.mock.calls;
+      const resendCall = calls.find((c) =>
+        String(c[0]).includes("resend-email")
+      );
+      expect(resendCall).toBeDefined();
+      expect(resendCall?.[1]).toEqual({ email: "user@example.com" });
+    });
+  });
+});

--- a/frontend/next-app/src/app/auth/verify/[key]/page.tsx
+++ b/frontend/next-app/src/app/auth/verify/[key]/page.tsx
@@ -23,12 +23,16 @@ type VerifyState =
 export default function VerifyPage() {
   const params = useParams();
   const router = useRouter();
-  const key =
+  const rawKey =
     typeof params?.key === "string"
       ? params.key
       : Array.isArray(params?.key)
         ? params.key[0]
         : "";
+  // Trim whitespace defensively — terminal copy-paste of the activate_url
+  // sometimes includes a trailing newline or space which the URL bar silently
+  // preserves, and the backend treats whitespace-suffixed keys as invalid (404).
+  const key = rawKey.trim();
   const hasRun = useRef(false);
   const [state, setState] = useState<VerifyState>({ status: "loading" });
   const [resendEmail, setResendEmail] = useState("");

--- a/frontend/next-app/src/app/auth/verify/[key]/page.tsx
+++ b/frontend/next-app/src/app/auth/verify/[key]/page.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import axios from "axios";
+import { useParams, useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { CheckCircle, Warning, Clock } from "@phosphor-icons/react";
+
+const apiBaseUrl =
+  process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000/api/v1";
+
+type VerifyState =
+  | { status: "loading" }
+  | { status: "success" }
+  | { status: "expired" }
+  | { status: "invalid" }
+  | { status: "already_verified" }
+  | { status: "error" };
+
+export default function VerifyPage() {
+  const params = useParams();
+  const router = useRouter();
+  const key =
+    typeof params?.key === "string"
+      ? params.key
+      : Array.isArray(params?.key)
+        ? params.key[0]
+        : "";
+  const hasRun = useRef(false);
+  const [state, setState] = useState<VerifyState>({ status: "loading" });
+  const [resendEmail, setResendEmail] = useState("");
+  const [resendState, setResendState] = useState<
+    "idle" | "sending" | "sent" | "error"
+  >("idle");
+
+  useEffect(() => {
+    if (hasRun.current || !key) return;
+    hasRun.current = true;
+
+    (async () => {
+      try {
+        const response = await axios.post(
+          `${apiBaseUrl}/dj-rest-auth/registration/verify-and-login/`,
+          { key }
+        );
+        const { key: token, user } = response.data as {
+          key: string;
+          user: number | string;
+        };
+        window.localStorage.setItem("token", token);
+        window.localStorage.setItem("userId", String(user));
+        setState({ status: "success" });
+        router.push("/dashboard");
+      } catch (err) {
+        if (axios.isAxiosError(err) && err.response) {
+          const status = err.response.status;
+          if (status === 410) setState({ status: "expired" });
+          else if (status === 404) setState({ status: "invalid" });
+          else if (status === 409) setState({ status: "already_verified" });
+          else setState({ status: "error" });
+        } else {
+          setState({ status: "error" });
+        }
+      }
+    })();
+  }, [key, router]);
+
+  const handleResend = async () => {
+    if (!resendEmail) return;
+    setResendState("sending");
+    try {
+      await axios.post(
+        `${apiBaseUrl}/dj-rest-auth/registration/resend-email/`,
+        { email: resendEmail }
+      );
+      setResendState("sent");
+    } catch {
+      setResendState("error");
+    }
+  };
+
+  return (
+    <div className="min-h-[100dvh] bg-background flex items-center justify-center px-4 py-16">
+      <div className="w-full max-w-md rounded-[1.5rem] bg-card p-8 border border-border">
+        {state.status === "loading" && (
+          <div className="text-center" role="status" aria-live="polite">
+            <div className="mx-auto w-fit">
+              <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-primary" />
+            </div>
+            <p className="mt-4 text-sm text-muted-foreground">
+              Verifying your email...
+            </p>
+          </div>
+        )}
+
+        {state.status === "success" && (
+          <div className="text-center" role="status" aria-live="polite">
+            <div className="mx-auto w-fit rounded-full bg-success/10 p-3 text-success">
+              <CheckCircle size={24} weight="regular" />
+            </div>
+            <p className="mt-4 text-sm text-muted-foreground">
+              Verified. Taking you in...
+            </p>
+          </div>
+        )}
+
+        {(state.status === "expired" || state.status === "invalid") && (
+          <>
+            <div className="mx-auto w-fit rounded-full bg-warm/10 p-3 text-warm">
+              <Clock size={24} weight="regular" />
+            </div>
+            <h1 className="mt-4 text-2xl font-extrabold tracking-tight text-foreground text-center">
+              {state.status === "expired"
+                ? "This link has expired"
+                : "This link isn't valid"}
+            </h1>
+            <p className="mt-2 text-sm text-muted-foreground text-center">
+              {state.status === "expired"
+                ? "Verification links expire after 24 hours. Enter your email and we'll send a fresh one."
+                : "We couldn't match this link to a pending verification. Enter the email you registered with and we'll send a fresh link."}
+            </p>
+            <div className="mt-6 space-y-3">
+              <div className="space-y-1.5">
+                <Label
+                  htmlFor="resend-email"
+                  className="text-xs font-medium text-muted-foreground"
+                >
+                  Email
+                </Label>
+                <Input
+                  id="resend-email"
+                  type="email"
+                  value={resendEmail}
+                  onChange={(e) => setResendEmail(e.target.value)}
+                  placeholder="you@example.com"
+                  className="h-10 rounded-lg"
+                />
+              </div>
+              <Button
+                onClick={handleResend}
+                disabled={resendState === "sending" || !resendEmail}
+                className="w-full h-11 rounded-lg"
+              >
+                {resendState === "sending" ? "Sending..." : "Send a new link"}
+              </Button>
+              <div role="status" aria-live="polite">
+                {resendState === "sent" && (
+                  <p className="text-sm text-success text-center">
+                    Sent! Check your inbox.
+                  </p>
+                )}
+                {resendState === "error" && (
+                  <p className="text-sm text-destructive text-center">
+                    Couldn&apos;t send. Try again in a moment.
+                  </p>
+                )}
+              </div>
+            </div>
+          </>
+        )}
+
+        {state.status === "already_verified" && (
+          <>
+            <div className="mx-auto w-fit rounded-full bg-success/10 p-3 text-success">
+              <CheckCircle size={24} weight="regular" />
+            </div>
+            <h1 className="mt-4 text-2xl font-extrabold tracking-tight text-foreground text-center">
+              You&apos;re already verified
+            </h1>
+            <p className="mt-2 text-sm text-muted-foreground text-center">
+              This email is confirmed. Head to the login page to sign in.
+            </p>
+            <Link href="/login" className="block mt-6">
+              <Button className="w-full h-11 rounded-lg">Go to login</Button>
+            </Link>
+          </>
+        )}
+
+        {state.status === "error" && (
+          <>
+            <div className="mx-auto w-fit rounded-full bg-destructive/10 p-3 text-destructive">
+              <Warning size={24} weight="regular" />
+            </div>
+            <h1 className="mt-4 text-2xl font-extrabold tracking-tight text-foreground text-center">
+              Something went wrong
+            </h1>
+            <p className="mt-2 text-sm text-muted-foreground text-center">
+              We couldn&apos;t reach the server. Try again?
+            </p>
+            <Button
+              onClick={() => {
+                hasRun.current = false;
+                setState({ status: "loading" });
+              }}
+              className="w-full h-11 rounded-lg mt-6"
+            >
+              Try again
+            </Button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/next-app/src/components/auth/LoginPage.test.tsx
+++ b/frontend/next-app/src/components/auth/LoginPage.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import axios, { AxiosError } from "axios";
+import LoginPage from "./LoginPage";
+
+jest.mock("axios");
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, replace: jest.fn(), prefetch: jest.fn() }),
+}));
+
+describe("LoginPage — unverified-account path", () => {
+  beforeEach(() => {
+    mockedAxios.post.mockReset();
+    mockedAxios.isAxiosError.mockImplementation(
+      (err): err is AxiosError => Boolean(err && (err as any).isAxiosError)
+    );
+    mockPush.mockReset();
+    window.localStorage.clear();
+  });
+
+  const submitLogin = async () => {
+    fireEvent.change(screen.getByLabelText(/username/i), {
+      target: { value: "unverified" },
+    });
+    fireEvent.change(screen.getAllByLabelText(/password/i)[0], {
+      target: { value: "anything" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /sign.*in|log.*in|open.*shed/i }));
+  };
+
+  it("on unverified-error response, shows an inline banner about verification", async () => {
+    mockedAxios.post.mockRejectedValueOnce({
+      isAxiosError: true,
+      response: {
+        status: 400,
+        data: { non_field_errors: ["E-mail is not verified."] },
+      },
+    });
+
+    render(<LoginPage />);
+    await submitLogin();
+
+    await waitFor(() =>
+      expect(screen.getByText(/email.*isn.t verified/i)).toBeInTheDocument()
+    );
+  });
+
+  it("auto-fires a resend exactly once when unverified banner appears", async () => {
+    // First call: login with 400 unverified.
+    mockedAxios.post.mockRejectedValueOnce({
+      isAxiosError: true,
+      response: {
+        status: 400,
+        data: { non_field_errors: ["E-mail is not verified."] },
+      },
+    });
+    // Second call: auto-resend succeeds.
+    mockedAxios.post.mockResolvedValueOnce({ data: { detail: "ok" } });
+
+    render(<LoginPage />);
+    await submitLogin();
+
+    await waitFor(() => {
+      const resendCalls = mockedAxios.post.mock.calls.filter((c) =>
+        String(c[0]).includes("resend-email")
+      );
+      expect(resendCalls).toHaveLength(1);
+    });
+
+    // Second submission with the same unverified response must NOT re-fire
+    // the auto-resend. Manual resend button still available (tested below).
+    mockedAxios.post.mockRejectedValueOnce({
+      isAxiosError: true,
+      response: {
+        status: 400,
+        data: { non_field_errors: ["E-mail is not verified."] },
+      },
+    });
+    await submitLogin();
+
+    await waitFor(() => {
+      const resendCalls = mockedAxios.post.mock.calls.filter((c) =>
+        String(c[0]).includes("resend-email")
+      );
+      expect(resendCalls).toHaveLength(1); // still 1, no double-fire
+    });
+  });
+
+  it("manual resend button fires another /resend-email/ call on demand", async () => {
+    mockedAxios.post.mockRejectedValueOnce({
+      isAxiosError: true,
+      response: {
+        status: 400,
+        data: { non_field_errors: ["E-mail is not verified."] },
+      },
+    });
+    mockedAxios.post.mockResolvedValueOnce({ data: { detail: "ok" } });
+
+    render(<LoginPage />);
+    await submitLogin();
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /resend/i })
+      ).toBeInTheDocument()
+    );
+
+    mockedAxios.post.mockResolvedValueOnce({ data: { detail: "ok" } });
+    fireEvent.click(screen.getByRole("button", { name: /resend/i }));
+
+    await waitFor(() => {
+      const resendCalls = mockedAxios.post.mock.calls.filter((c) =>
+        String(c[0]).includes("resend-email")
+      );
+      expect(resendCalls.length).toBeGreaterThanOrEqual(2); // auto + manual
+    });
+  });
+});

--- a/frontend/next-app/src/components/auth/LoginPage.test.tsx
+++ b/frontend/next-app/src/components/auth/LoginPage.test.tsx
@@ -25,7 +25,7 @@ describe("LoginPage — unverified-account path", () => {
 
   const submitLogin = async () => {
     fireEvent.change(screen.getByLabelText(/username/i), {
-      target: { value: "unverified" },
+      target: { value: "unverified@example.com" },
     });
     fireEvent.change(screen.getAllByLabelText(/password/i)[0], {
       target: { value: "anything" },
@@ -70,6 +70,7 @@ describe("LoginPage — unverified-account path", () => {
         String(c[0]).includes("resend-email")
       );
       expect(resendCalls).toHaveLength(1);
+      expect(resendCalls[0][1]).toEqual({ email: "unverified@example.com" });
     });
 
     // Second submission with the same unverified response must NOT re-fire

--- a/frontend/next-app/src/components/auth/LoginPage.tsx
+++ b/frontend/next-app/src/components/auth/LoginPage.tsx
@@ -91,13 +91,9 @@ const LoginPage = () => {
           m.toLowerCase().includes("not verified")
         )
       ) {
-        // Use the typed username as the resend target. If the user logged in
-        // with a plain username (not an email), the resend call may be
-        // rejected server-side — that's caught silently. Users who typed an
-        // email-as-username get the happy auto-resend path; users with a
-        // separate username/email can still use the manual resend button or
-        // visit /auth/check-email directly.
-        setUnverifiedEmail(formData.username);
+        setUnverifiedEmail(
+          formData.username.includes("@") ? formData.username : null
+        );
         setError("");
         return;
       }

--- a/frontend/next-app/src/components/auth/LoginPage.tsx
+++ b/frontend/next-app/src/components/auth/LoginPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import axios, { AxiosError } from "axios";
 import { useRouter } from "next/navigation";
@@ -17,6 +17,11 @@ const LoginPage = () => {
   });
   const [error, setError] = useState("");
   const [isLoading, setIsLoading] = useState(false);
+  const [unverifiedEmail, setUnverifiedEmail] = useState<string | null>(null);
+  const [manualResendState, setManualResendState] = useState<
+    "idle" | "sending" | "sent" | "error"
+  >("idle");
+  const autoResendFiredRef = useRef(false);
   const router = useRouter();
 
   useEffect(() => {
@@ -25,6 +30,38 @@ const LoginPage = () => {
       router.replace("/dashboard");
     }
   }, [router]);
+
+  useEffect(() => {
+    if (!unverifiedEmail || autoResendFiredRef.current) return;
+    autoResendFiredRef.current = true;
+    const apiBaseUrl =
+      process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000/api/v1";
+    void (async () => {
+      try {
+        await axios.post(`${apiBaseUrl}/dj-rest-auth/registration/resend-email/`, {
+          email: unverifiedEmail,
+        });
+      } catch {
+        // Silent failure on auto-fire — manual resend button remains.
+      }
+    })();
+  }, [unverifiedEmail]);
+
+  const handleManualResend = async () => {
+    if (!unverifiedEmail) return;
+    setManualResendState("sending");
+    const apiBaseUrl =
+      process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000/api/v1";
+    try {
+      await axios.post(
+        `${apiBaseUrl}/dj-rest-auth/registration/resend-email/`,
+        { email: unverifiedEmail }
+      );
+      setManualResendState("sent");
+    } catch {
+      setManualResendState("error");
+    }
+  };
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setFormData({ ...formData, [e.target.name]: e.target.value });
@@ -46,6 +83,24 @@ const LoginPage = () => {
       router.push("/dashboard");
     } catch (err) {
       console.error("Login error", err);
+      if (
+        axios.isAxiosError(err) &&
+        err.response?.status === 400 &&
+        Array.isArray(err.response?.data?.non_field_errors) &&
+        err.response.data.non_field_errors.some((m: string) =>
+          m.toLowerCase().includes("not verified")
+        )
+      ) {
+        // Use the typed username as the resend target. If the user logged in
+        // with a plain username (not an email), the resend call may be
+        // rejected server-side — that's caught silently. Users who typed an
+        // email-as-username get the happy auto-resend path; users with a
+        // separate username/email can still use the manual resend button or
+        // visit /auth/check-email directly.
+        setUnverifiedEmail(formData.username);
+        setError("");
+        return;
+      }
       if (axios.isAxiosError(err)) {
         const axiosError = err as AxiosError<{ detail?: string }>;
         setError(
@@ -145,6 +200,34 @@ const LoginPage = () => {
               </p>
 
               <form onSubmit={handleSubmit} className="mt-6 space-y-4">
+                {unverifiedEmail && (
+                  <div
+                    role="status"
+                    aria-live="polite"
+                    className="rounded-lg border border-warm/40 bg-warm/10 p-3 text-sm"
+                  >
+                    <p className="font-medium text-foreground">
+                      Your email isn&apos;t verified yet
+                    </p>
+                    <p className="mt-1 text-muted-foreground">
+                      We sent you a fresh link to{" "}
+                      <strong className="text-foreground">{unverifiedEmail}</strong>.
+                    </p>
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      onClick={handleManualResend}
+                      disabled={manualResendState === "sending"}
+                      className="mt-2 h-9 rounded-lg"
+                    >
+                      {manualResendState === "sending"
+                        ? "Sending..."
+                        : manualResendState === "sent"
+                          ? "Sent!"
+                          : "Resend"}
+                    </Button>
+                  </div>
+                )}
                 {error && (
                   <div className="rounded-lg bg-destructive/[0.06] px-3.5 py-2.5 text-sm font-medium text-destructive">
                     {error}

--- a/frontend/next-app/src/components/auth/RegisterPage.test.tsx
+++ b/frontend/next-app/src/components/auth/RegisterPage.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import axios from "axios";
+import RegisterPage from "./RegisterPage";
+
+jest.mock("axios");
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, replace: jest.fn(), prefetch: jest.fn() }),
+}));
+
+describe("RegisterPage", () => {
+  beforeEach(() => {
+    mockedAxios.post.mockReset();
+    mockPush.mockReset();
+  });
+
+  it("on successful registration, redirects to /auth/check-email with the email", async () => {
+    mockedAxios.post.mockResolvedValueOnce({ data: { detail: "Verification e-mail sent." } });
+
+    render(<RegisterPage />);
+    fireEvent.change(screen.getByLabelText(/username/i), { target: { value: "newuser" } });
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: "new@example.com" } });
+    const passwordInputs = screen.getAllByLabelText(/password/i);
+    fireEvent.change(passwordInputs[0], { target: { value: "StrongPass123!" } });
+    fireEvent.change(passwordInputs[1], { target: { value: "StrongPass123!" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /create.*account|sign.*up|register/i }));
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith(
+        expect.stringContaining("/auth/check-email?email=new%40example.com")
+      );
+    });
+  });
+});

--- a/frontend/next-app/src/components/auth/RegisterPage.tsx
+++ b/frontend/next-app/src/components/auth/RegisterPage.tsx
@@ -61,7 +61,7 @@ const RegisterPage = () => {
 
       try {
         await axios.post(apiUrl, formData);
-        router.push("/login");
+        router.push(`/auth/check-email?email=${encodeURIComponent(formData.email)}`);
       } catch (error) {
         console.error("Registration error", error);
         if (axios.isAxiosError(error)) {

--- a/templates/account/email/email_confirmation_message.html
+++ b/templates/account/email/email_confirmation_message.html
@@ -1,0 +1,28 @@
+{% load i18n %}<!DOCTYPE html>
+<html>
+<body style="margin: 0; font-family: system-ui, -apple-system, sans-serif; background: #fbfbfa; padding: 32px 16px; color: #37352f;">
+  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="max-width: 480px; margin: 0 auto; background: #ffffff; border-radius: 12px;">
+    <tr>
+      <td style="padding: 32px;">
+        <h1 style="font-size: 20px; margin: 0 0 16px; color: #37352f;">Verify your email</h1>
+        <p style="font-size: 15px; line-height: 1.5; margin: 0 0 24px;">
+          Hey <strong>{{ user.username }}</strong>, click the button below to sign in and start practicing.
+        </p>
+        <p style="text-align: center; margin: 32px 0;">
+          <a href="{{ activate_url }}"
+             style="display: inline-block; padding: 12px 28px; background: #0D9488; color: #ffffff; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 15px;">
+            Sign me in
+          </a>
+        </p>
+        <p style="font-size: 13px; color: #78716c; line-height: 1.5; margin: 0 0 8px;">
+          Or paste this link into your browser:
+        </p>
+        <p style="font-size: 13px; color: #78716c; word-break: break-all; margin: 0 0 24px;">
+          <a href="{{ activate_url }}" style="color: #78716c;">{{ activate_url }}</a>
+        </p>
+        <p style="font-size: 13px; color: #78716c; margin: 0;">Expires in 24 hours.</p>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/templates/account/email/email_confirmation_message.txt
+++ b/templates/account/email/email_confirmation_message.txt
@@ -1,0 +1,9 @@
+Hey {{ user.username }},
+
+Click the link below to verify your email and sign in. The link expires in 24 hours.
+
+{{ activate_url }}
+
+Didn't sign up for this? Ignore this email.
+
+— The Shed

--- a/templates/account/email/email_confirmation_subject.txt
+++ b/templates/account/email/email_confirmation_subject.txt
@@ -1,0 +1,1 @@
+Verify your email and get into The Shed


### PR DESCRIPTION
## Summary

Closes #16. Replaces the current register → redirect-to-login flow with a mandatory-verify + magic-link-login flow:

1. User registers → account created unverified, email sent via SendGrid (console backend in dev).
2. User sees a dedicated "check your email" screen with a resend affordance.
3. User clicks the link on any device → `/auth/verify/[key]` page POSTs to a new `verify-and-login` endpoint that confirms the email **and** issues a DRF token in one round-trip.
4. Frontend stores the token + userId and redirects to `/dashboard`. One click from inbox to practicing.

## What's in this PR

**Backend**
- New `POST /api/v1/dj-rest-auth/registration/verify-and-login/` endpoint wrapping allauth's `EmailConfirmation.confirm()` + issuing a DRF `Token` in one response (same shape as `/login/`).
- `CustomAccountAdapter` routes confirmation URLs to `${FRONTEND_URL}/auth/verify/<key>`.
- `ACCOUNT_EMAIL_VERIFICATION = "mandatory"` flips the gate so unverified accounts can't log in. `ACCOUNT_EMAIL_SUBJECT_PREFIX = "[The Shed] "` replaces Django's default `[example.com]` prefix.
- SendGrid SMTP gated on `SENDGRID_API_KEY`. Console backend is the dev default — emails print to the web logs.
- Startup check raises `ImproperlyConfigured` if `FRONTEND_URL` is missing when `DEBUG=False`.
- Data migration `0002_grandfather_existing_users` idempotently marks pre-existing `EmailAddress` rows `verified=True, primary=True`, creating rows for users who don't have one. Case-insensitive email matching, demotes stale primaries, and normalizes `CustomUser.email` to lowercase so dj-rest-auth's case-sensitive login filter matches the verified row. Forward-only (reversing would re-unverify everyone). Lands before the mandatory-verify gate so existing users aren't locked out.
- Email templates (subject/text/HTML) overridden under `templates/account/email/` — single CTA button, email-client-safe inline CSS.

**Frontend**
- New `/auth/check-email?email=...` post-register screen with manual resend button.
- New `/auth/verify/[key]` callback page with 6 render states: loading, success (auto-redirect), expired (resend form), invalid (resend form), already-verified (go-to-login link), error (retry). `aria-live` on all status regions.
- `RegisterPage` now redirects to `/auth/check-email?email=...` on success.
- `LoginPage` detects unverified-email error, shows inline banner, auto-fires resend once on first arrival (guarded with `useRef`), exposes a manual "Resend" button. Only fires the auto-resend when the typed username is email-shaped.

## Test coverage

| Layer | Count | Notes |
|-------|-------|-------|
| Backend | 78 tests | 7 grandfather (idempotency, multi-primary, mixed-case, CustomUser normalization), 2 adapter, 7 settings + 3 startup-check, 8 verify (all 4 status codes including HMAC-expired path), + 53 pre-existing |
| Frontend | 58 tests | 4 check-email, 5 verify callback (every render state), 1 RegisterPage redirect, 3 LoginPage unverified, + 45 pre-existing |
| Typecheck | ✅ | `npx tsc --noEmit` clean |

Plus full end-to-end integration smoke against the live backend (register → capture activate_url → POST verify-and-login → confirm 200 + token; re-click same key → 409 `already_verified`; login with verified user → token; `dan` grandfather check still passes).

## Deploy checklist (Railway)

**Before merging**, set these env vars on the **backend** Railway service:

- `SENDGRID_API_KEY=<your-SendGrid-Mail-Send-key>` — created via SendGrid Settings → API Keys → Restricted Access (Mail Send only).
- `DEFAULT_FROM_EMAIL=dandiggasmusic@gmail.com` — the address verified via SendGrid Settings → Sender Authentication → Single Sender Verification.
- `FRONTEND_URL=https://<your-frontend>.railway.app` — must be the public frontend URL, no trailing slash. The startup check will refuse to boot the container without this when `DEBUG=False`.

**Frontend** service (should already be set from the metronome PR):
- `NEXT_PUBLIC_API_URL=https://<your-backend>.railway.app/api/v1`

## Post-deploy smoke

- [ ] Register a throwaway account on the live URL.
- [ ] Confirm the email arrives **from SendGrid** (not console), `From: dandiggasmusic@gmail.com`, `Subject: [The Shed] Verify your email and get into The Shed`.
- [ ] Click the link on a different device. Expect auto-login + `/dashboard`.
- [ ] Try logging in with that user normally — should succeed (token-based login works post-verify).

## Known follow-ups (not this PR)

- **#45** — Rate-limit `/verify-and-login/` and `/resend-email/`. Not a launch blocker with unguessable HMAC keys + low volume, but should land before the app has real traffic.
- Domain authentication on SendGrid (for better deliverability) once a custom domain is available. Current single-sender setup ships via SendGrid's shared IPs.
- Post-verify onboarding UX on `/dashboard` for day-zero users (empty state polish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)